### PR TITLE
Argon Viewer passes root Argon Region to Field Editor

### DIFF
--- a/mapclientplugins/argonviewerstep/view/argonviewerwidget.py
+++ b/mapclientplugins/argonviewerstep/view/argonviewerwidget.py
@@ -85,8 +85,7 @@ class ArgonViewerWidget(QtWidgets.QMainWindow):
         self.dockWidgetContentsRegionEditor.setRootRegion(rootRegion)
         self.dockWidgetContentsSceneEditor.setZincRootRegion(zincRootRegion)
 
-        self.dockWidgetContentsFieldEditor.setFieldmodule(zincRootRegion.getFieldmodule())
-        self.dockWidgetContentsFieldEditor.setArgonRegion(rootRegion)
+        self.dockWidgetContentsFieldEditor.setRootArgonRegion(rootRegion)
         self.dockWidgetContentsFieldEditor.setTimekeeper(zincContext.getTimekeepermodule().getDefaultTimekeeper())
 
         if self._visualisation_view_ready:


### PR DESCRIPTION
Needed for simultaneous change to FieldListEditorWidgets in opencmiss.zincwidgets which now has a region chooser.

See opencmiss-bindings/opencmiss.zincwidgets#21